### PR TITLE
Fix Bug 14413

### DIFF
--- a/Date.php
+++ b/Date.php
@@ -465,18 +465,41 @@ class Date
      *
      * @param mixed $date                optional ISO 8601 date/time to initialize;
      *                                    or, a Unix time stamp
-     * @param bool  $pb_countleapseconds whether to count leap seconds
+     * @param mixed $options             optional with backwards compatibility;
+     *                                    accept bool whether to count leap seconds
      *                                    (defaults to
-     *                                    {@link DATE_COUNT_LEAP_SECONDS})
+     *                                    {@link DATE_COUNT_LEAP_SECONDS});
+     *                                    accept array options with default options:
+     *                                    'pb_countleapseconds' to count leap seconds
+     *                                    (defaults to
+     *                                    {@link DATE_COUNT_LEAP_SECONDS});
+     *                                    'format' (DATE_FORMAT_*) of the input date.
+     *                                    This option is not needed, except to force
+     *                                    the setting of the date from a Unix
+     *                                    time-stamp (for which use
+     *                                    {@link DATE_FORMAT_UNIXTIME}).
+     *                                    (Defaults to
+     *                                    {@link DATE_FORMAT_ISO}.)
      *
      * @return   void
      * @access   public
      * @see      Date::setDate()
      */
-    function Date($date = null,
-                  $pb_countleapseconds = DATE_COUNT_LEAP_SECONDS)
+    function Date($date = null, $options = null)
     {
-        $this->ob_countleapseconds = $pb_countleapseconds;
+		$default = array(
+		    "pb_countleapseconds" => DATE_COUNT_LEAP_SECONDS,
+		    "format" => DATE_FORMAT_ISO
+		);
+		if (is_null($options)) {
+			$options = array();
+	    }
+		if (is_bool($options)) {
+			$options["pb_countleapseconds"] = $options;
+	    }
+	    $args = array_merge($default, $options);
+
+        $this->ob_countleapseconds = $args["pb_countleapseconds"];
 
         if (is_a($date, 'Date')) {
             $this->copy($date);
@@ -485,7 +508,7 @@ class Date
                 // 'setDate()' expects a time zone to be already set:
                 //
                 $this->_setTZToDefault();
-                $this->setDate($date);
+                $this->setDate($date, $args["format"]);
             } else {
                 $this->setNow();
             }

--- a/tests/bugs/bug-2378-1.phpt
+++ b/tests/bugs/bug-2378-1.phpt
@@ -6,7 +6,7 @@ Bug #2378: Date::getDate(DATE_FORMAT_UNIXTIME) doesn't convert to GMT
 require_once "Date.php";
 
 
-$date =& new Date(1095935549);
+$date =& new Date(1095935549, array('format' => DATE_FORMAT_UNIXTIME));
 echo $date->getTime()."\n";
 $date->convertTZbyID('America/Los_Angeles');
 echo $date->getTime()."\n";

--- a/tests/bugs/bug-8912.phpt
+++ b/tests/bugs/bug-8912.phpt
@@ -25,7 +25,7 @@ $originalTimezone = new Date_TimeZone('Australia/Adelaide');
 $d = new Date("2007-08-31 11:59:59Z");
 $hn_time = $d->getTime();
 foreach ($states as $state) {
-    $new_date = new Date($hn_time);
+    $new_date = new Date($hn_time, array('format' => DATE_FORMAT_UNIXTIME));
     print 'Original Time (Australia/Adelaide): ' . $new_date->formatLikeSQL("TZH:TZM") . " " . $new_date->getTime() . "\n";
     $timezone = new Date_TimeZone($state);
     $new_date->convertTZ($timezone);
@@ -38,49 +38,49 @@ foreach ($states as $state) {
 }
 ?>
 --EXPECT--
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Adelaide: 1188561599
 Difference: 0
 Australia/Adelaide: 1188561599
 Difference: 0
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Canberra: 1188561599
 Difference: 0
 Australia/Canberra: 1188563399
 Difference: 1800
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Darwin: 1188561599
 Difference: 0
 Australia/Darwin: 1188561599
 Difference: 0
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Brisbane: 1188561599
 Difference: 0
 Australia/Brisbane: 1188563399
 Difference: 1800
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Hobart: 1188561599
 Difference: 0
 Australia/Hobart: 1188563399
 Difference: 1800
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Melbourne: 1188561599
 Difference: 0
 Australia/Melbourne: 1188563399
 Difference: 1800
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Perth: 1188561599
 Difference: 0
 Australia/Perth: 1188556199
 Difference: -5400
 
-Original Time (Australia/Adelaide): 01:00 1188561599
+Original Time (Australia/Adelaide): 00:00 1188561599
 Australia/Sydney: 1188561599
 Difference: 0
 Australia/Sydney: 1188563399


### PR DESCRIPTION
Greetings, we use the Pear Date project and noticed the following issues:
https://pear.php.net/bugs/bug.php?id=14413
https://pear.php.net/bugs/bug.php?id=2378
https://pear.php.net/bugs/bug.php?id=8912
Fix for 14413 (8912 unit tests) adjusted test expectations from 01:00 to 00:00.
Fix for 14413 (2378-1 unit tests) added array() parameter for BC and forced unix-timestamp.

It should be noted the 8912 unit test originally didn't have a THZ:THM requirement.  I couldn't find any discussion on why it was added in, nor could I find any logical reason why "01:00" was the correct value whereas "00:00" was not.  Given the rest of the values and tests seemed to pass, I modified the test expectations.

$ pear run-tests -r
Running 20 tests
PASS [ 1/20] Bug #445: Date does not handle DATE_FORMAT_ISO_EXTENDED correctly[tests/bugs/bug-445.phpt]
PASS [ 2/20] Bug #674: strange (wrong?) result of Date_Calc::endOfWeek[tests/bugs/bug-674.phpt]
PASS [ 3/20] Bug #727: Date_Calc::weeksInMonth() wrong result
Tests for weeksInMonth, february with 4 weeks
Monday as 1st day of week[tests/bugs/bug-727-1.phpt]
PASS [ 4/20] Bug #727: Date_Calc::weeksInMonth() wrong result
Tests for weeksInMonth, february with 4 weeks
Sunday as 1st day of week[tests/bugs/bug-727-2.phpt]
PASS [ 5/20] Bug #727: Date_Calc::weeksInMonth() wrong result
Tests for weeksInMonth "random"
Sunday as 1st day of week[tests/bugs/bug-727-3.phpt]
PASS [ 6/20] Bug #727: Date_Calc::weeksInMonth() wrong result
Tests for weeksInMonth "random"
Monday as 1st day of week[tests/bugs/bug-727-4.phpt]
PASS [ 7/20] Bug #967: Date_TimeZone uses a bad global variable[tests/bugs/bug-967.phpt]
PASS [ 8/20] Bug #2378: Date::getDate(DATE_FORMAT_UNIXTIME) doesn't convert to GMT[tests/bugs/bug-2378-1.phpt]
PASS [ 9/20] Bug #2378: Date::getDate(DATE_FORMAT_UNIXTIME) doesn't convert to GMT[tests/bugs/bug-2378.phpt]
PASS [10/20] Bug #6246: Date::inDaylightTime() crashes Apache 2.0.55 with status 3221225477[tests/bugs/bug-6246.phpt]
PASS [11/20] Bug #8518: Date::copy() doest not copy the parts of a second.[tests/bugs/bug-8518.phpt]
PASS [12/20] Bug #8912: putenv() causes crashes in DateTimeZone::inDaylightTime() under windows[tests/bugs/bug-8912.phpt]
PASS [13/20] Bug #9213: Date_Calc doesn't like including Date.php[tests/bugs/bug-9213.phpt]
PASS [14/20] Bug #9414: Date::addSeconds() fails to work properly with negative numbers[tests/bugs/bug-9414.phpt]
PASS [15/20] Bug #9568:
Date_Calc::beginOfMonthBySpan() and Date_Calc::endOfMonthBySpan() -
December was always shifted up one year[tests/bugs/bug-9568.phpt]
PASS [16/20] Bug #9801: Date::compare() modify params on PHP5[tests/bugs/bug-9801.phpt]
PASS [17/20] Bug #11313 DST time change not handled correctly[tests/bugs/bug-11313.phpt]
PASS [18/20] Bug #13376 setFromDateDiff change the source of Date objects[tests/bugs/bug-13376.phpt]
PASS [19/20] Bug #13545 Date_Span::set() doesn't work when passed an int and format[tests/bugs/bug-13545.phpt]
PASS [20/20] Bug #19568 setDate() handles ISO week dates incorrectly[tests/bugs/bug-19568.phpt]
TOTAL TIME: 00:02
20 PASSED TESTS
0 SKIPPED TESTS
